### PR TITLE
Add context-aware workspace symbol detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpc-vscode",
   "displayName": "GPC Language Tools",
   "description": "GPC Language Tools for VSCode",
-  "version": "1.2.0",
+  "version": "1.2.4",
   "internal-version": "1.2.3",
   "publisher": "zkiwiko",
   "license": "GPL-3.0-only",
@@ -58,6 +58,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show parameter names in function calls"
+        },
+        "gpc.mainFile": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the main GPC file (relative to workspace root). Symbols from this file and its includes will be globally available. Leave empty for auto-detection (looks for main.gpc or a file with main() function)."
         }
       }
     },

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,8 +1,9 @@
 import { Diagnostic } from "vscode-languageserver";
 import { Parser } from "./parser/parser";
+import { GlobalSymbols } from "./parser/visitor";
 
 export class ErrorCollector {
-  public static collectErrors(input: string): Diagnostic[] {
-    return Parser.getErrors(input);
+  public static collectErrors(input: string, globalSymbols?: GlobalSymbols): Diagnostic[] {
+    return Parser.getErrors(input, globalSymbols);
   }
 }


### PR DESCRIPTION
## Summary

Implements per-folder main file detection and global symbol context to prevent false "undefined variable/function" errors in multi-project workspaces.

## Features

- **Auto-detects main file** per directory (searches for `main.gpc` or files with `main()` function)
- **Upward search**: Searches from current file to workspace root for the nearest main file
- **Per-main-file caching**: Global symbols are cached per main file for performance
- **Smart symbol merging**: Merges global symbols after first pass to avoid duplicate declaration errors
- **Multi-project support**: Multiple projects (e.g., different games) can coexist in same workspace
- **Configuration override**: `gpc.mainFile` setting for manual override

## Technical Implementation

- Modified `Visitor` to merge global symbols between first and second pass in `visitProgram()`
- Added `detectMainFileForPath()` for context-aware main file detection
- Implemented per-main-file symbol caching (`mainFileCache`, `globalSymbolsCache`)
- Updated validation to use context-specific global symbols
- Enhanced revalidation logic for main file changes

## Use Case

Perfect for workspaces with multiple game projects:

Games/
----Apex/
--------main.gpc       ← Defines globalConfig
--------combo.gpc      ← Can use globalConfig without #include
----Arc/
--------main.gpc       ← Different main file
--------combo.gpc      ← Uses Arc's main file symbols

Each file automatically gets symbols from its nearest main file, eliminating false errors while maintaining proper validation.